### PR TITLE
ECDC-2937 Update version and add unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-graylog-logger"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "stable"
+conan_pkg_channel = "testing"
 
 container_build_bodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import ecdcpipeline.ConanPackageBuilder
 project = "conan-graylog-logger"
 
 conan_user = "ess-dmsc"
-conan_pkg_channel = "testing"
+conan_pkg_channel = "stable"
 
 container_build_bodes = [
   'centos': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,9 +4,10 @@ from conans import ConanFile, CMake, tools
 class GraylogloggerConan(ConanFile):
     name = "graylog-logger"
     version_number = "2.1.4"
-    version = f"{version_number}"
+    version = f"{version_number}-dm1"
     license = "BSD 2-Clause"
     url = "https://bintray.com/ess-dmsc/graylog-logger"
+    build_requires = ("gtest/1.11.0",)
     requires = ("nlohmann_json/3.10.5", "asio/1.22.1", "concurrentqueue/1.0.3", "fmt/8.1.1")
     settings = "os", "compiler", "build_type", "arch"
     generators = ("cmake_find_package")

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class GraylogloggerConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.build()
         cmake.build(target="unit_tests")
-        self.run("unit_tests/unit_tests")
+        self.run("unit_tests/unit_tests --gtest_filter=-'*IPv6*'")
 
         if tools.os_info.is_macos:
             os.system("install_name_tool -id '@rpath/libgraylog_logger.dylib' "

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 class GraylogloggerConan(ConanFile):
     name = "graylog-logger"
     version_number = "2.1.4"
-    version = f"{version_number}-dm1"
+    version = f"{version_number}"
     license = "BSD 2-Clause"
     url = "https://bintray.com/ess-dmsc/graylog-logger"
     build_requires = ("gtest/1.11.0",)
@@ -31,6 +31,8 @@ class GraylogloggerConan(ConanFile):
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
+        cmake.build(target="unit_tests")
+        self.run("unit_tests/unit_tests")
 
         if tools.os_info.is_macos:
             os.system("install_name_tool -id '@rpath/libgraylog_logger.dylib' "

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake, tools
 
 class GraylogloggerConan(ConanFile):
     name = "graylog-logger"
-    version_number = "2.1.3"
+    version_number = "2.1.4"
     version = f"{version_number}"
     license = "BSD 2-Clause"
     url = "https://bintray.com/ess-dmsc/graylog-logger"


### PR DESCRIPTION
Use a more recent version of graylog-logger and run unit tests when creating package.